### PR TITLE
API documentation & Readme file updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The function `Fatal` logs the messages and then calls `panic`. It can be used fo
 # Imports
 ```go
 import (	
-    "github.com/takecontrolsoft/go_multi_log/levels"
-	"github.com/takecontrolsoft/go_multi_log/logger"
-	"github.com/takecontrolsoft/go_multi_log/loggers"
+    "github.com/takecontrolsoft/go_multi_log/logger"
+	"github.com/takecontrolsoft/go_multi_log/logger/levels"
+	"github.com/takecontrolsoft/go_multi_log/logger/loggers"
 )
 ````	
 # Usage

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # go_multi_log
-Go package go_multi_log that provides logging in multiple loggers (console, file and other) with log levels.
+Go package "go_multi_log" that provides logging in multiple loggers (console, file and other) with log levels.
 
+# Register **[Multiple Logger Types](#multiple-logger-types)**
+* [Console logger](#console-logger) (defaults)
+* [File logger](#file-logger)
+* [Custom logger](#custom-logger)
 
-Default log level is `Info`, which means that only `Info`, `Warning`, `Error` and `Fatal` messages will be logged.
-The function `Fatal` logs the messages and then calls `panic`. It can be used for fatal errors and it will ensure storing the log into a file before closing the application.
+# Get started
+* Default log level is `Info`, which means that only `Info`, `Warning`, `Error` and `Fatal` messages will be logged, but `Debug` and `Trace` messages will be skipped.
+* The function `Fatal` logs the messages and then calls `panic`. It can be used for fatal errors and it will ensure storing the log into a file before closing the application.
 
-# Imports
+## Imports
 ```go
 import (	
     "github.com/takecontrolsoft/go_multi_log/logger"
@@ -13,8 +18,8 @@ import (
 	"github.com/takecontrolsoft/go_multi_log/logger/loggers"
 )
 ````	
-# Usage
-## Log messages:
+## Usage
+### Log messages:
 
 ```go
     logger.Info("Test info log message")
@@ -23,12 +28,12 @@ import (
     logger.Fatal("Test log fatal message") // The function Fatal logs the messages and then calls Panic.
 ```
 
-## Log error object:
+### Log error object:
 ```go
 err := callFunction()
 logger.Error(err)
 ```
-## Log any object
+### Log any object
 
 ```go	
 type person struct{ Name string }
@@ -36,7 +41,7 @@ person := person{Name: "Michael"}
 logger.Info(person)	
 ```
 
-## Log formatted message
+### Log formatted message
 Using formatting functions `DebugF`, `TraceF`, `InfoF`, `WarningF`, `ErrorF`, `FatalF`
 
 ```go	
@@ -49,7 +54,7 @@ car := car{Year: "2020"}
 logger.InfoF("Person: %v, Car: %v", person, car)	
 ```
 
-## Change log level
+### Change log level
 To change the default log level use `SetLevel(levels.All)`. This will cause all the messages for levels greater or equal to the new level also to be logged. The level is changed for the whole application. Avoid changing the level inside Goroutine (go lightweight thread).
        
 ```go
@@ -58,7 +63,7 @@ logger.DefaultLogger().SetLevel(levels.All)
 logger.Debug("Test debug log message")
 logger.Trace("Test trace log message")
 ```
-## Stop and Start logging
+### Stop and Start logging
 No messages will be logged after calling `Stop` function.
 Logging could be resumed with calling `Start` function.
 In this example only "Message 2" will be logged.
@@ -69,8 +74,60 @@ logger.DefaultLogger().Start()
 logger.Info("Message 2")		
 ```
 
-# Logger types
+## Multiple Logger Types
 
-## Console logger
-## File logger
-## Implement custom logger
+### Manage loggers
+Use the following functions to **register**, **unregister** or **get** loggers by key. One **default logger** always exists and can not be unregistered, but can be stopped.
+
+```go
+key:="new_logger_key" // where the key must be unique, because more than one instances of the same logger type can be registered.
+
+logger.RegisterLogger(key, logger) // where `logger` implements `loggers.LoggerInterface` and can support different log levels and log destinations.
+
+logger.GetLogger(key) // will return an instance of the logger by key.
+
+logger.UnregisterLogger(key) // will delete a specific logger from the collection with registered loggers.
+
+logger.DefaultLogger() // will return an instance of the default logger of type `ConsoleLogger`
+```
+
+### Console logger
+`ConsoleLogger` is set by default and it can be obtained from `logger.DefaultLogger()`. This logger can not be unregistered, but it can be stopped and resumed.
+Another customized logger instead can be registered for example to log only Debug messages using new formatting string. See the example:
+
+```go
+logger.DefaultLogger().Stop()
+c := loggers.NewConsoleLogger(levels.Debug, "***debug:'%s'")
+_, err := logger.RegisterLogger("debug_log_key", c)
+```
+
+### File logger
+`FileLogger` can be added as an additional logger to prints the messages to files. 
+#### Use `NewFileLoggerDefault` to initialize the file logger with the default settings.
+   * Default [LogLevel] is levels.Info.
+   * Default [FileOptions] are used:
+        * FilePrefix:  "sync_server".
+        * FileExtension:  ".log".
+        * *Directory: current executable directory.
+```go
+f := loggers.NewFileLoggerDefault()
+_, err := logger.RegisterLogger("file_logger_key", f)
+```
+
+#### Use `NewFileLogger` to initialize the file logger with the customized settings.
+```go
+level := levels.Error
+format := "***error:'%s'"
+fileOptions := loggers.FileOptions{
+    Directory:     "./",
+    FilePrefix:    generateRandomString(5),
+    FileExtension: ".txt",
+}
+
+f := loggers.NewFileLogger(level, format, fileOptions)
+_, err := logger.RegisterLogger("txt_file_key", f)
+	
+```
+### Custom logger
+Custom loggers implementations can be easily added by implementing the interface `loggers.LoggerInterface` or deriving the base class `loggers.LoggerType`, which already implements most of the function.
+

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The function `Fatal` logs the messages and then calls `panic`. It can be used fo
 # Imports
 ```go
 import (	
-    "github.com/takecontrolsoft/go_multi_log/logger"
-    "github.com/takecontrolsoft/go_multi_log/logger/levels"
-    "github.com/takecontrolsoft/go_multi_log/logger/loggers"
+    "github.com/takecontrolsoft/go_multi_log/levels"
+	"github.com/takecontrolsoft/go_multi_log/logger"
+	"github.com/takecontrolsoft/go_multi_log/loggers"
 )
 ````	
 # Usage
@@ -50,11 +50,11 @@ logger.InfoF("Person: %v, Car: %v", person, car)
 ```
 
 ## Change log level
-To change the default log level use `SetLevel(levels.AllLevels)`. This will cause all the messages for levels greater or equal to the new level also to be logged. The level is changed for the whole application. Avoid changing the level inside Goroutine (go lightweight thread).
+To change the default log level use `SetLevel(levels.All)`. This will cause all the messages for levels greater or equal to the new level also to be logged. The level is changed for the whole application. Avoid changing the level inside Goroutine (go lightweight thread).
        
 ```go
 currentLevel:= logger.DefaultLogger().GetLevel()
-logger.DefaultLogger().SetLevel(levels.AllLevels)
+logger.DefaultLogger().SetLevel(levels.All)
 logger.Debug("Test debug log message")
 logger.Trace("Test trace log message")
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,4 @@ module github.com/takecontrolsoft/go_multi_log
 go 1.21
 
 require github.com/go-errors/errors v1.5.1 // indirect
+

--- a/go.work
+++ b/go.work
@@ -3,4 +3,6 @@ go 1.21
 use (
 	.
 	./logger
+	./logger/loggers
+	./logger/levels
 )

--- a/logger/.log
+++ b/logger/.log
@@ -1,5 +1,0 @@
-2024/01/13 11:50:56 DEBUG: [Test log [debug] message]
-2024/01/13 11:50:56 TRACE: [Test log [trace] message]
-2024/01/13 11:50:56 INFO: [Test log [info] message]
-2024/01/13 11:50:56 ERROR: [Test error.]
-2024/01/13 11:50:56 ERROR: [Test log [error] message]

--- a/logger/go.mod
+++ b/logger/go.mod
@@ -2,5 +2,5 @@ module github.com/takecontrolsoft/go_multi_log/logger
 
 go 1.21
 
-require github.com/timandy/routine v1.1.3
 require github.com/go-errors/errors v1.5.1 // indirect
+

--- a/logger/go.sum
+++ b/logger/go.sum
@@ -1,4 +1,0 @@
-github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
-github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
-github.com/timandy/routine v1.1.3 h1:lK7ix0Oyprtuw301bNle7WZw9V8eY680mjT9r5rmBLA=
-github.com/timandy/routine v1.1.3/go.mod h1:XWkchlwnVxH+yRwA/yxSuyzxqiaNuBUcFUHDglX56SY=

--- a/logger/go.work.sum
+++ b/logger/go.work.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
+github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/logger/levels/go.mod
+++ b/logger/levels/go.mod
@@ -1,0 +1,3 @@
+module github.com/takecontrolsoft/go_multi_log/logger/levels
+
+go 1.21

--- a/logger/levels/levels.go
+++ b/logger/levels/levels.go
@@ -13,14 +13,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package "levels" provides constants for different log levels
+// Based on the level the logged messages could be filtered.
+// Multiple loggers could be configured to log messages from different levels.
 package levels
 
+// LogLevel type represents the supported log levels
+type LogLevel int
+
 const (
-	AllLevels    int = 0
-	DebugLevel   int = 1
-	TraceLevel   int = 2
-	InfoLevel    int = 3
-	WarningLevel int = 4
-	ErrorLevel   int = 5
-	FatalLevel   int = 6
+	All     LogLevel = 0
+	Debug   LogLevel = 1
+	Trace   LogLevel = 2
+	Info    LogLevel = 3
+	Warning LogLevel = 4
+	Error   LogLevel = 5
+	Fatal   LogLevel = 6
 )
+
+// Converts to string the name of the LogLevel value
+func (level LogLevel) String() string {
+	switch level {
+	case Debug:
+		return "Debug"
+	case Trace:
+		return "Trace"
+	case Info:
+		return "Info"
+	case Warning:
+		return "Warning"
+	case Error:
+		return "Error"
+	case Fatal:
+		return "Fatal"
+	default:
+		return "Unknown"
+	}
+}

--- a/logger/loggers/console_logger.go
+++ b/logger/loggers/console_logger.go
@@ -28,24 +28,24 @@ type ConsoleLogger struct {
 
 func NewConsoleLoggerDefault() *ConsoleLogger {
 	return &ConsoleLogger{
-		LoggerType: LoggerType{Level: levels.InfoLevel},
+		LoggerType: LoggerType{Level: levels.Info},
 	}
 }
 
-func NewConsoleLogger(level int, format string) *ConsoleLogger {
+func NewConsoleLogger(level levels.LogLevel, format string) *ConsoleLogger {
 	return &ConsoleLogger{
 		LoggerType: LoggerType{Level: level, Format: format},
 	}
 }
 
-func (logger *ConsoleLogger) Log(level int, arg any) {
+func (logger *ConsoleLogger) Log(level levels.LogLevel, arg any) {
 	if logger.IsLogAllowed(level) {
 		log.SetOutput(os.Stdout)
 		logger.multi_log(level, arg)
 	}
 }
 
-func (logger *ConsoleLogger) LogF(level int, format string, args ...interface{}) {
+func (logger *ConsoleLogger) LogF(level levels.LogLevel, format string, args ...interface{}) {
 	if logger.IsLogAllowed(level) {
 		log.SetOutput(os.Stdout)
 		logger.multi_logF(level, format, args...)

--- a/logger/loggers/console_logger.go
+++ b/logger/loggers/console_logger.go
@@ -22,22 +22,31 @@ import (
 	"github.com/takecontrolsoft/go_multi_log/logger/levels"
 )
 
+// [ConsoleLogger] type represents the logger that print
+// the messages to the standard output [os.Stdout].
 type ConsoleLogger struct {
 	LoggerType
 }
 
+// Returns an instance of [ConsoleLogger] with
+// default log level "Info".
 func NewConsoleLoggerDefault() *ConsoleLogger {
 	return &ConsoleLogger{
 		LoggerType: LoggerType{Level: levels.Info},
 	}
 }
 
+// Returns an instance of [ConsoleLogger] with
+// given log level and format string defined by the caller.
 func NewConsoleLogger(level levels.LogLevel, format string) *ConsoleLogger {
 	return &ConsoleLogger{
 		LoggerType: LoggerType{Level: level, Format: format},
 	}
 }
 
+// Prints the message or the object "arg" into the console.
+// If there is no format set when initializing this [ConsoleLogger],
+// a default format is used: {time} {log level}: [{message}]
 func (logger *ConsoleLogger) Log(level levels.LogLevel, arg any) {
 	if logger.IsLogAllowed(level) {
 		log.SetOutput(os.Stdout)
@@ -45,6 +54,9 @@ func (logger *ConsoleLogger) Log(level levels.LogLevel, arg any) {
 	}
 }
 
+// Prints one or more objects "args" into the console
+// as a message formatted using the given format string
+// by the caller.
 func (logger *ConsoleLogger) LogF(level levels.LogLevel, format string, args ...interface{}) {
 	if logger.IsLogAllowed(level) {
 		log.SetOutput(os.Stdout)

--- a/logger/loggers/file_logger.go
+++ b/logger/loggers/file_logger.go
@@ -31,10 +31,18 @@ type FileLogger struct {
 	FileOptions
 }
 
+// Represent a set of file options,
+// which are used when the log file name is generated.
 type FileOptions struct {
 	Directory, FilePrefix, FileExtension string
 }
 
+// Returns an instance of [FileLogger] with
+// default log level "Info".
+// Default [FileOptions] are used:
+//   - FilePrefix:  "sync_server"
+//   - FileExtension:  ".log"
+//   - Directory: current executable directory.
 func NewFileLoggerDefault() *FileLogger {
 	return &FileLogger{
 		LoggerType:  LoggerType{Level: levels.Info},
@@ -42,6 +50,11 @@ func NewFileLoggerDefault() *FileLogger {
 	}
 }
 
+// Returns an instance of [FileLogger] with
+// given log level and format string defined by the caller.
+// [FileOptions] are not required, but could be used for setting the
+// file name prefix and file extension as well as the path location,
+// where the log files to be stored.
 func NewFileLogger(level levels.LogLevel, format string, options FileOptions) *FileLogger {
 	return &FileLogger{
 		LoggerType:  LoggerType{Level: level, Format: format},
@@ -49,6 +62,9 @@ func NewFileLogger(level levels.LogLevel, format string, options FileOptions) *F
 	}
 }
 
+// Prints the message or the object "arg" into files (named with goroutine id).
+// If there is no format set when initializing this [FileLogger],
+// a default format is used: {time} {log level}: [{message}]
 func (logger *FileLogger) Log(level levels.LogLevel, arg any) {
 	if logger.IsLogAllowed(level) {
 		fLog := setFileLog(logger)
@@ -57,6 +73,8 @@ func (logger *FileLogger) Log(level levels.LogLevel, arg any) {
 	}
 }
 
+// Prints one or more objects "args" into files (named with goroutine id)
+// as a message formatted using the given format string by the caller.
 func (logger *FileLogger) LogF(level levels.LogLevel, format string, args ...interface{}) {
 	if logger.IsLogAllowed(level) {
 		fLog := setFileLog(logger)

--- a/logger/loggers/file_logger.go
+++ b/logger/loggers/file_logger.go
@@ -25,6 +25,7 @@ import (
 	"github.com/timandy/routine"
 )
 
+// A FileLogger is safe for concurrent use by multiple goroutines
 type FileLogger struct {
 	LoggerType
 	FileOptions
@@ -36,19 +37,19 @@ type FileOptions struct {
 
 func NewFileLoggerDefault() *FileLogger {
 	return &FileLogger{
-		LoggerType:  LoggerType{Level: levels.InfoLevel},
+		LoggerType:  LoggerType{Level: levels.Info},
 		FileOptions: FileOptions{FilePrefix: "sync_server", FileExtension: ".log"},
 	}
 }
 
-func NewFileLogger(level int, format string, options FileOptions) *FileLogger {
+func NewFileLogger(level levels.LogLevel, format string, options FileOptions) *FileLogger {
 	return &FileLogger{
 		LoggerType:  LoggerType{Level: level, Format: format},
 		FileOptions: options,
 	}
 }
 
-func (logger *FileLogger) Log(level int, arg any) {
+func (logger *FileLogger) Log(level levels.LogLevel, arg any) {
 	if logger.IsLogAllowed(level) {
 		fLog := setFileLog(logger)
 		defer fLog.Close()
@@ -56,7 +57,7 @@ func (logger *FileLogger) Log(level int, arg any) {
 	}
 }
 
-func (logger *FileLogger) LogF(level int, format string, args ...interface{}) {
+func (logger *FileLogger) LogF(level levels.LogLevel, format string, args ...interface{}) {
 	if logger.IsLogAllowed(level) {
 		fLog := setFileLog(logger)
 		defer fLog.Close()

--- a/logger/loggers/file_logger.go
+++ b/logger/loggers/file_logger.go
@@ -33,6 +33,9 @@ type FileLogger struct {
 
 // Represent a set of file options,
 // which are used when the log file name is generated.
+//   - Directory - an absolute or relative path to log files location where the process has write access.
+//   - FilePrefix - should be a short string of symbols allowed for OS file names.
+//   - FileExtension - should starts with ".".
 type FileOptions struct {
 	Directory, FilePrefix, FileExtension string
 }
@@ -40,9 +43,9 @@ type FileOptions struct {
 // Returns an instance of [FileLogger] with
 // default log level "Info".
 // Default [FileOptions] are used:
+//   - Directory: current executable directory.
 //   - FilePrefix:  "sync_server"
 //   - FileExtension:  ".log"
-//   - Directory: current executable directory.
 func NewFileLoggerDefault() *FileLogger {
 	return &FileLogger{
 		LoggerType:  LoggerType{Level: levels.Info},

--- a/logger/loggers/go.mod
+++ b/logger/loggers/go.mod
@@ -1,0 +1,5 @@
+module github.com/takecontrolsoft/go_multi_log/logger/loggers
+
+go 1.21
+
+require github.com/timandy/routine v1.1.3

--- a/logger/loggers/logger_interface.go
+++ b/logger/loggers/logger_interface.go
@@ -13,6 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package "loggers" provides different implementations for loggers,
+// which are possible to be registered.
+// The package supports:
+//   - [loggers.ConsoleLogger], which logs the messages to the console
+//   - [loggers.FileLogger], which logs the messages to files separated by goroutines.
+//
+// The common interface [loggers.LoggerInterface]
+// makes it possible this package to be extended by implementing
+// additional custom loggers for logging in json, xml and other formats,
+// as well as sending the logs to external services.
 package loggers
 
 import (
@@ -23,72 +33,68 @@ import (
 	"github.com/takecontrolsoft/go_multi_log/logger/levels"
 )
 
+// This interface describes all the methods required to be implemented by the loggers.
+// Each logger, which implements this interface could be registered
+// to log messages and objects
 type LoggerInterface interface {
-	Log(level int, arg any)
-	LogF(level int, format string, args ...interface{})
-	GetLevel() int
-	SetLevel(level int)
+	Log(level levels.LogLevel, arg any)
+	LogF(level levels.LogLevel, format string, args ...interface{})
+	GetLevel() levels.LogLevel
+	SetLevel(level levels.LogLevel)
 	Start()
 	Stop()
 }
 
+// Provides base implementation of [loggers.LoggerInterface]
+// and can be reused when extending the package with adding new
+// loggers implementations.
 type LoggerType struct {
 	LoggerInterface
-	Level  int
+	Level  levels.LogLevel
 	Format string
 
 	isStopped bool
 }
 
-func (logger *LoggerType) IsLogAllowed(level int) bool {
+// Reports if the log message will be printed based on the
+// log level. The log level can be set for a specific logger
+// using [loggers.LoggerType.SetLevel].
+// [loggers.LoggerType.IsLogAllowed] returns false if the logger
+// is stopped using [loggers.LoggerType.Stop] function.
+func (logger *LoggerType) IsLogAllowed(level levels.LogLevel) bool {
 	return !logger.isStopped && level >= logger.Level
 }
 
-func (logger *LoggerType) GetLevel() int {
+// Reports the log level for this logger.
+func (logger *LoggerType) GetLevel() levels.LogLevel {
 	return logger.Level
 }
 
-func (logger *LoggerType) SetLevel(level int) {
+// Sets the log level for this logger.
+func (logger *LoggerType) SetLevel(level levels.LogLevel) {
 	logger.Level = level
 }
 
+// Resumes printing logs by this logger.
 func (logger *LoggerType) Start() {
 	logger.isStopped = false
 }
 
+// Stops printing logs by this logger.
 func (logger *LoggerType) Stop() {
 	logger.isStopped = true
 }
 
-func (logger *LoggerType) multi_log(level int, arg any) {
+func (logger *LoggerType) multi_log(level levels.LogLevel, arg any) {
 	var f string
 	if len(logger.Format) > 0 {
 		f = logger.Format
 	} else {
-		f = fmt.Sprintf("%s: [%s]", strings.ToUpper(GetLogLevelName(level)), "%v")
+		f = fmt.Sprintf("%s: [%s]", strings.ToUpper(level.String()), "%v")
 	}
 	logger.multi_logF(level, f, arg)
 }
 
-func (logger *LoggerType) multi_logF(level int, format string, args ...interface{}) {
+func (logger *LoggerType) multi_logF(level levels.LogLevel, format string, args ...interface{}) {
 	log.Printf(format, args...)
-}
-
-func GetLogLevelName(level int) string {
-	switch logLevel := level; logLevel {
-	case levels.DebugLevel:
-		return "Debug"
-	case levels.TraceLevel:
-		return "Trace"
-	case levels.InfoLevel:
-		return "Info"
-	case levels.WarningLevel:
-		return "Warning"
-	case levels.ErrorLevel:
-		return "Error"
-	case levels.FatalLevel:
-		return "Fatal"
-	default:
-		return "Unknown"
-	}
 }

--- a/logger/loggers/logger_interface.go
+++ b/logger/loggers/logger_interface.go
@@ -33,9 +33,9 @@ import (
 	"github.com/takecontrolsoft/go_multi_log/logger/levels"
 )
 
-// This interface describes all the methods required to be implemented by the loggers.
+// [LoggerInterface] describes all the methods required to be implemented by the loggers.
 // Each logger, which implements this interface could be registered
-// to log messages and objects
+// to log messages and objects.
 type LoggerInterface interface {
 	Log(level levels.LogLevel, arg any)
 	LogF(level levels.LogLevel, format string, args ...interface{})
@@ -45,7 +45,7 @@ type LoggerInterface interface {
 	Stop()
 }
 
-// Provides base implementation of [loggers.LoggerInterface]
+// [LoggerType] provides base implementation of [loggers.LoggerInterface]
 // and can be reused when extending the package with adding new
 // loggers implementations.
 type LoggerType struct {

--- a/logger/multi_logger.go
+++ b/logger/multi_logger.go
@@ -84,8 +84,8 @@ func logFAll(fn fnLogF, format string, level levels.LogLevel, args ...interface{
 	}
 }
 
-// Register an instance of an additional logger that implements
-// [loggers.LoggerInterface]
+// Register an instance of an additional logger
+// that implements [loggers.LoggerInterface].
 func RegisterLogger(key string, logger loggers.LoggerInterface) (loggers.LoggerInterface, error) {
 	if len(key) == 0 {
 		return logger, errors.Errorf("Empty key is not allowed for registering loggers.").Err

--- a/logger/multi_logger.go
+++ b/logger/multi_logger.go
@@ -86,23 +86,23 @@ func logFAll(fn fnLogF, format string, level levels.LogLevel, args ...interface{
 
 // Register an instance of an additional logger
 // that implements [loggers.LoggerInterface].
-func RegisterLogger(key string, logger loggers.LoggerInterface) (loggers.LoggerInterface, error) {
+func RegisterLogger(key string, logger loggers.LoggerInterface) error {
 	if len(key) == 0 {
-		return logger, errors.Errorf("Empty key is not allowed for registering loggers.").Err
+		return errors.Errorf("Empty key is not allowed for registering loggers.").Err
 	}
 	mLogger = getMultiLog()
 	mLogger.registered_loggers[key] = logger
-	return logger, nil
+	return nil
 }
 
-func UnregisterLogger(key string) (loggers.LoggerInterface, error) {
+func UnregisterLogger(key string) error {
 	mLogger = getMultiLog()
 	logger := mLogger.registered_loggers[key]
 	if logger == nil {
-		return nil, errors.Errorf("A logger for given key does not exists.").Err
+		return errors.Errorf("A logger for given key does not exists.").Err
 	}
 	delete(mLogger.registered_loggers, key)
-	return logger, nil
+	return nil
 }
 
 func GetLogger(key string) loggers.LoggerInterface {

--- a/logger/multi_logger.go
+++ b/logger/multi_logger.go
@@ -56,34 +56,36 @@ func getMultiLog() *multiLog {
 	return mLogger
 }
 
-type fnLog func(logger loggers.LoggerInterface, level int, arg any)
-type fnLogF func(logger loggers.LoggerInterface, format string, level int, args ...interface{})
+type fnLog func(logger loggers.LoggerInterface, level levels.LogLevel, arg any)
+type fnLogF func(logger loggers.LoggerInterface, format string, level levels.LogLevel, args ...interface{})
 
-func _log(logger loggers.LoggerInterface, level int, arg any) {
+func _log(logger loggers.LoggerInterface, level levels.LogLevel, arg any) {
 	logger.Log(level, arg)
 }
 
-func _logF(logger loggers.LoggerInterface, format string, level int, args ...interface{}) {
+func _logF(logger loggers.LoggerInterface, format string, level levels.LogLevel, args ...interface{}) {
 	logger.LogF(level, format, args...)
 }
 
-func logAll(fn fnLog, level int, arg any) {
+func logAll(fn fnLog, level levels.LogLevel, arg any) {
 	mLogger = getMultiLog()
 	for _, logger := range mLogger.registered_loggers {
 		fn(logger, level, arg)
 	}
-	if level == levels.FatalLevel {
+	if level == levels.Fatal {
 		panic(arg)
 	}
 }
 
-func logFAll(fn fnLogF, format string, level int, args ...interface{}) {
+func logFAll(fn fnLogF, format string, level levels.LogLevel, args ...interface{}) {
 	mLogger = getMultiLog()
 	for _, logger := range mLogger.registered_loggers {
 		fn(logger, format, level, args...)
 	}
 }
 
+// Register an instance of an additional logger that implements
+// [loggers.LoggerInterface]
 func RegisterLogger(key string, logger loggers.LoggerInterface) (loggers.LoggerInterface, error) {
 	if len(key) == 0 {
 		return logger, errors.Errorf("Empty key is not allowed for registering loggers.").Err
@@ -114,49 +116,49 @@ func DefaultLogger() loggers.LoggerInterface {
 }
 
 func Debug(arg any) {
-	logAll(_log, levels.DebugLevel, arg)
+	logAll(_log, levels.Debug, arg)
 }
 
 func Trace(arg any) {
-	logAll(_log, levels.TraceLevel, arg)
+	logAll(_log, levels.Trace, arg)
 }
 
 func Info(arg any) {
-	logAll(_log, levels.InfoLevel, arg)
+	logAll(_log, levels.Info, arg)
 }
 
 func Warning(arg any) {
-	logAll(_log, levels.WarningLevel, arg)
+	logAll(_log, levels.Warning, arg)
 }
 
 func Error(arg any) {
-	logAll(_log, levels.ErrorLevel, arg)
+	logAll(_log, levels.Error, arg)
 }
 
 func Fatal(arg any) {
-	logAll(_log, levels.FatalLevel, arg)
+	logAll(_log, levels.Fatal, arg)
 }
 
 func DebugF(format string, args ...interface{}) {
-	logFAll(_logF, format, levels.DebugLevel, args...)
+	logFAll(_logF, format, levels.Debug, args...)
 }
 
 func TraceF(format string, args ...interface{}) {
-	logFAll(_logF, format, levels.TraceLevel, args...)
+	logFAll(_logF, format, levels.Trace, args...)
 }
 
 func InfoF(format string, args ...interface{}) {
-	logFAll(_logF, format, levels.InfoLevel, args...)
+	logFAll(_logF, format, levels.Info, args...)
 }
 
 func WarningF(format string, args ...interface{}) {
-	logFAll(_logF, format, levels.WarningLevel, args...)
+	logFAll(_logF, format, levels.Warning, args...)
 }
 
 func ErrorF(format string, args ...interface{}) {
-	logFAll(_logF, format, levels.ErrorLevel, args...)
+	logFAll(_logF, format, levels.Error, args...)
 }
 
 func FatalF(format string, args ...interface{}) {
-	logFAll(_logF, format, levels.FatalLevel, args...)
+	logFAll(_logF, format, levels.Fatal, args...)
 }

--- a/multi_logger_test.go
+++ b/multi_logger_test.go
@@ -113,6 +113,24 @@ func TestStopLog(t *testing.T) {
 	assert.Contains(t, content, "INFO: [Test info log message 2]")
 }
 
+func TestCustomizedConsoleLog(t *testing.T) {
+	logger.DefaultLogger().Stop()
+	c := loggers.NewConsoleLogger(levels.Debug, "***debug:'%s'")
+	_, err := logger.RegisterLogger("debug_log", c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, c.Level, levels.Debug)
+	assert.Equal(t, logger.GetLogger("debug_log").GetLevel(), c.Level)
+	content := readConsole(func() {
+		logger.Debug("Test log debug message")
+		logger.Info("Test log info message")
+	})
+
+	assert.NotContains(t, content, "Test info log message")
+	assert.Contains(t, content, "***debug:'Test log debug message'")
+}
+
 func TestAddFileLog(t *testing.T) {
 	fileLogger := loggers.NewFileLoggerDefault()
 	_, err := logger.RegisterLogger("file", fileLogger)

--- a/multi_logger_test.go
+++ b/multi_logger_test.go
@@ -123,14 +123,15 @@ func TestCustomizedConsoleLog(t *testing.T) {
 	logger.DefaultLogger().Stop()
 	defer logger.DefaultLogger().Start()
 	c := loggers.NewConsoleLogger(levels.Debug, "console:***debug:'%s'")
-	_, err := logger.RegisterLogger("debug_log_key", c)
+	key := "debug_log_key"
+	err := logger.RegisterLogger(key, c)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer logger.UnregisterLogger("debug_log_key")
+	defer logger.UnregisterLogger(key)
 
 	assert.Equal(t, c.Level, levels.Debug)
-	assert.Equal(t, logger.GetLogger("debug_log").GetLevel(), c.Level)
+	assert.Equal(t, logger.GetLogger(key).GetLevel(), c.Level)
 	content := readConsole(func() {
 		logger.Debug("Test log debug message")
 		logger.Info("Test log info message")
@@ -142,11 +143,12 @@ func TestCustomizedConsoleLog(t *testing.T) {
 
 func TestAddFileLog(t *testing.T) {
 	fileLogger := loggers.NewFileLoggerDefault()
-	_, err := logger.RegisterLogger("file_log_key", fileLogger)
+	key := "file_log_key"
+	err := logger.RegisterLogger(key, fileLogger)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer logger.UnregisterLogger("file_log_key")
+	defer logger.UnregisterLogger(key)
 
 	logger.Info("Test log info message")
 
@@ -173,11 +175,11 @@ func TestCustomizedFileLog(t *testing.T) {
 
 	fileLogger := loggers.NewFileLogger(level, format, fileOptions)
 	key := "txt_file"
-	_, err := logger.RegisterLogger(key, fileLogger)
+	err := logger.RegisterLogger(key, fileLogger)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer logger.UnregisterLogger("file_log_key")
+	defer logger.UnregisterLogger(key)
 
 	logger.DefaultLogger().Stop()
 	defer logger.DefaultLogger().Stop()

--- a/multi_logger_test.go
+++ b/multi_logger_test.go
@@ -63,7 +63,7 @@ func TestAllLogs(t *testing.T) {
 }
 
 func TestLogFormattedObject(t *testing.T) {
-	logger.DefaultLogger().SetLevel(levels.AllLevels)
+	logger.DefaultLogger().SetLevel(levels.All)
 	content := readConsole(func() {
 		person := person{Name: "Michael"}
 		logger.DebugF("Person: %v, Car: %v", person, car{Year: "2020"})
@@ -81,7 +81,7 @@ func TestLogFormattedObject(t *testing.T) {
 }
 
 func TestLogLevels(t *testing.T) {
-	logger.DefaultLogger().SetLevel(levels.TraceLevel)
+	logger.DefaultLogger().SetLevel(levels.Trace)
 	content := readConsole(func() {
 		logger.Debug("Test debug log message")
 		logger.Trace("Test trace log message")
@@ -134,7 +134,7 @@ func TestAddFileLog(t *testing.T) {
 }
 
 func TestCustomizedFileLog(t *testing.T) {
-	level := levels.ErrorLevel
+	level := levels.Error
 	format := "***error:'%s'"
 	fileOptions := loggers.FileOptions{
 		Directory:     "./",

--- a/multi_logger_test.go
+++ b/multi_logger_test.go
@@ -115,7 +115,7 @@ func TestStopLog(t *testing.T) {
 
 func TestCustomizedConsoleLog(t *testing.T) {
 	logger.DefaultLogger().Stop()
-	c := loggers.NewConsoleLogger(levels.Debug, "***debug:'%s'")
+	c := loggers.NewConsoleLogger(levels.Debug, "console:***debug:'%s'")
 	_, err := logger.RegisterLogger("debug_log", c)
 	if err != nil {
 		t.Fatal(err)
@@ -128,7 +128,7 @@ func TestCustomizedConsoleLog(t *testing.T) {
 	})
 
 	assert.NotContains(t, content, "Test info log message")
-	assert.Contains(t, content, "***debug:'Test log debug message'")
+	assert.Contains(t, content, "console:***debug:'Test log debug message'")
 }
 
 func TestAddFileLog(t *testing.T) {
@@ -153,7 +153,7 @@ func TestAddFileLog(t *testing.T) {
 
 func TestCustomizedFileLog(t *testing.T) {
 	level := levels.Error
-	format := "***error:'%s'"
+	format := "file:***error:'%s'"
 	fileOptions := loggers.FileOptions{
 		Directory:     "./",
 		FilePrefix:    generateRandomString(5),
@@ -180,7 +180,7 @@ func TestCustomizedFileLog(t *testing.T) {
 	for _, f := range logFiles {
 		content := readFileContent(t, f)
 		os.Remove(f)
-		assert.Contains(t, content, "***error:'Test log error message'")
+		assert.Contains(t, content, "file:***error:'Test log error message'")
 		assert.NotContains(t, content, "Test log info message")
 	}
 }


### PR DESCRIPTION

## Multiple Logger Types

### Manage loggers
Use the following functions to **register**, **unregister** or **get** loggers by key. One **default logger** always exists and can not be unregistered, but can be stopped.

```go
key:="new_logger_key" // where the key must be unique, because more than one instances of the same logger type can be registered.

logger.RegisterLogger(key, logger) // where `logger` implements `loggers.LoggerInterface` and can support different log levels and log destinations.

logger.GetLogger(key) // will return an instance of the logger by key.

logger.UnregisterLogger(key) // will delete a specific logger from the collection with registered loggers.

logger.DefaultLogger() // will return an instance of the default logger of type `ConsoleLogger`
```

### Console logger
`ConsoleLogger` is set by default and it can be obtained from `logger.DefaultLogger()`. This logger can not be unregistered, but it can be stopped and resumed.
Another customized logger instead can be registered for example to log only Debug messages using new formatting string. See the example:

```go
logger.DefaultLogger().Stop()
c := loggers.NewConsoleLogger(levels.Debug, "***debug:'%s'")
_, err := logger.RegisterLogger("debug_log_key", c)
```

### File logger
`FileLogger` can be added as an additional logger to prints the messages to files. 
#### Use `NewFileLoggerDefault` to initialize the file logger with the default settings.
   * Default [LogLevel] is levels.Info.
   * Default [FileOptions] are used:
        * FilePrefix:  "sync_server".
        * FileExtension:  ".log".
        * *Directory: current executable directory.
```go
f := loggers.NewFileLoggerDefault()
_, err := logger.RegisterLogger("file_logger_key", f)
```

#### Use `NewFileLogger` to initialize the file logger with the customized settings.
```go
level := levels.Error
format := "***error:'%s'"
fileOptions := loggers.FileOptions{
    Directory:     "./",
    FilePrefix:    generateRandomString(5),
    FileExtension: ".txt",
}

f := loggers.NewFileLogger(level, format, fileOptions)
_, err := logger.RegisterLogger("txt_file_key", f)
	
```
### Custom logger
Custom loggers implementations can be easily added by implementing the interface `loggers.LoggerInterface` or deriving the base class `loggers.LoggerType`, which already implements most of the function.

